### PR TITLE
feat: add contributors page and update routing for contributors and l…

### DIFF
--- a/lib/src/common/routing/app_router.dart
+++ b/lib/src/common/routing/app_router.dart
@@ -6,6 +6,7 @@ import 'package:namma_wallet/src/features/bottom_navigation/presentation/namma_n
 import 'package:namma_wallet/src/features/calendar/presentation/calendar_view.dart';
 import 'package:namma_wallet/src/features/home/domain/generic_details_model.dart';
 import 'package:namma_wallet/src/features/home/presentation/home_view.dart';
+import 'package:namma_wallet/src/features/profile/presentation/contributors_page.dart';
 import 'package:namma_wallet/src/features/profile/presentation/db_viewer_page.dart';
 import 'package:namma_wallet/src/features/profile/presentation/license_view.dart';
 import 'package:namma_wallet/src/features/profile/presentation/profile_page.dart';
@@ -87,6 +88,11 @@ final router = GoRouter(
       path: AppRoute.license.path,
       name: AppRoute.license.name,
       builder: (context, state) => const LicenseView(),
+    ),
+    GoRoute(
+      path: AppRoute.contributors.path,
+      name: AppRoute.contributors.name,
+      builder: (context, state) => const ContributorsPage(),
     ),
   ],
 );

--- a/lib/src/common/routing/app_routes.dart
+++ b/lib/src/common/routing/app_routes.dart
@@ -17,6 +17,7 @@ enum AppRoute {
   // Settings and configuration
   settings(path: '/settings', name: 'settings'),
   license(path: '/license', name: 'license'),
+  contributors(path: '/contributors', name: 'contributors'),
 
   // Debug routes
   dbViewer(path: '/db-viewer', name: 'dbViewer');

--- a/lib/src/features/profile/presentation/contributors_page.dart
+++ b/lib/src/features/profile/presentation/contributors_page.dart
@@ -1,0 +1,185 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:namma_wallet/src/common/widgets/custom_back_button.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+// ----------------- Model -----------------
+class Contributor {
+  Contributor({
+    required this.name,
+    required this.avatarUrl,
+    required this.profileUrl,
+  });
+
+  factory Contributor.fromJson(Map<String, dynamic> json) {
+    return Contributor(
+      name: json['login'] as String,
+      avatarUrl: json['avatar_url'] as String,
+      profileUrl: json['html_url'] as String,
+    );
+  }
+  final String name;
+  final String avatarUrl;
+  final String profileUrl;
+}
+
+// ----------------- Contributors Page -----------------
+class ContributorsPage extends StatefulWidget {
+  const ContributorsPage({super.key});
+
+  @override
+  State<ContributorsPage> createState() => _ContributorsPageState();
+}
+
+class _ContributorsPageState extends State<ContributorsPage> {
+  late Future<List<Contributor>> _contributorsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _contributorsFuture = _fetchContributors();
+  }
+
+  Future<List<Contributor>> _fetchContributors() async {
+    final contributors = <Contributor>[];
+    var page = 1;
+    const perPage = 100;
+    const timeout = Duration(seconds: 10);
+
+    while (true) {
+      final uri = Uri.parse(
+        'https://api.github.com/repos/Namma-Flutter/namma_wallet/contributors',
+      ).replace(queryParameters: {
+        'per_page': perPage.toString(),
+        'page': page.toString(),
+      });
+
+      final response = await http.get(
+        uri,
+        headers: {
+          'User-Agent': 'namma_wallet',
+          'Accept': 'application/vnd.github.v3+json',
+        },
+      ).timeout(timeout);
+
+      if (response.statusCode == 200) {
+        final body = json.decode(response.body) as List<dynamic>;
+        if (body.isEmpty) {
+          break; // No more contributors
+        }
+        contributors.addAll(
+          body.map(
+            (json) => Contributor.fromJson(json as Map<String, dynamic>),
+          ),
+        );
+        page++;
+      } else {
+        throw Exception(
+          'Failed to load contributors: HTTP ${response.statusCode}\n'
+          'Response body: ${response.body}',
+        );
+      }
+    }
+
+    return contributors;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: const CustomBackButton(),
+        title: const Text('Contributors'),
+      ),
+      body: FutureBuilder<List<Contributor>>(
+        future: _contributorsFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          } else if (snapshot.hasError) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Icon(Icons.error_outline,
+                        size: 48, color: Colors.red),
+                    const SizedBox(height: 16),
+                    Text(
+                      'Error loading contributors',
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      '${snapshot.error}',
+                      textAlign: TextAlign.center,
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
+                  ],
+                ),
+              ),
+            );
+          } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
+            return const Center(
+              child: Padding(
+                padding: EdgeInsets.all(16),
+                child: Text('No contributors found.'),
+              ),
+            );
+          }
+
+          final contributors = snapshot.data!;
+          return ListView.builder(
+            padding: const EdgeInsets.all(16),
+            itemCount: contributors.length,
+            itemBuilder: (context, index) {
+              final contributor = contributors[index];
+              return Card(
+                margin: const EdgeInsets.only(bottom: 8),
+                elevation: 1,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: ListTile(
+                  leading: CircleAvatar(
+                    backgroundImage: NetworkImage(contributor.avatarUrl),
+                    radius: 24,
+                  ),
+                  title: Text(
+                    contributor.name,
+                    style: const TextStyle(fontWeight: FontWeight.w600),
+                  ),
+                  subtitle: Text(
+                    contributor.profileUrl,
+                    style: const TextStyle(fontSize: 12),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  trailing: const Icon(Icons.open_in_new, size: 20),
+                  onTap: () async {
+                    final url = Uri.parse(contributor.profileUrl);
+                    try {
+                      await launchUrl(url);
+                    } on Exception catch (_) {
+                      if (context.mounted) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Text(
+                              'Could not open ${contributor.profileUrl}',
+                            ),
+                          ),
+                        );
+                      }
+                    }
+                  },
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/src/features/profile/presentation/settings_screen.dart
+++ b/lib/src/features/profile/presentation/settings_screen.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
-import 'package:namma_wallet/src/common/routing/app_routes.dart';
 import 'package:namma_wallet/src/common/widgets/custom_back_button.dart';
 import 'package:namma_wallet/src/features/ai/fallback-parser/domain/enums/model_configs.dart';
 import 'package:namma_wallet/src/features/ai/fallback-parser/presentation/widget/model_download_tile.dart';
@@ -19,17 +17,8 @@ class SettingsScreen extends StatelessWidget {
         title: const Text('Settings'),
       ),
       body: ListView(
-        children: [
-          const ModelDownloadTile(model: Model.gemma3_1B),
-          ListTile(
-            leading: const Icon(Icons.article_outlined),
-            title: const Text('Licenses'),
-            subtitle: const Text('View open source licenses'),
-            trailing: const Icon(Icons.chevron_right),
-            onTap: () {
-              context.pushNamed(AppRoute.license.name);
-            },
-          ),
+        children: const [
+          ModelDownloadTile(model: Model.gemma3_1B),
         ],
       ),
     );


### PR DESCRIPTION
…icense sections

## 📝 Pull Request Checklist

Please ensure the following before submitting your PR:

- [x] **Avoid returning `Widget` from functions or getters.**  
  Instead, encapsulate reusable UI into separate `StatelessWidget` classes.  
  (Returning widgets from functions is an anti-pattern: it causes unnecessary rebuilds, makes debugging harder, and prevents proper DevTools tree inspection.)

- [x] **Always use `StatelessWidget`** for static UI components.  
  Widget classes (with `const` constructors where possible) improve performance and hot-reload behavior.

- [x] **Model classes must be generated using [`dart_mappable`](https://pub.dev/packages/dart_mappable)**.  
  Do not hand-write `toJson` / `fromJson` or equality methods—always rely on code generation (`build_runner`).

- [x] **Follow [Conventional Commits](https://www.conventionalcommits.org/) and branch naming conventions.**  
  Example commit: `feat: add login screen`  
  Example branch: `feature/login-screen`

- [x] **Code is formatted** before committing.  
  Run `fvm dart format .` (or ensure your IDE does this automatically).

- [x] **Follow naming conventions for widgets and views.**  
  Use "view" suffix for main/page widgets (`HomeView`, file: `home_view.dart`) and "widget" suffix for smaller reusable components (`TicketCardWidget`, file: `ticket_card_widget.dart`).

---

## 📌 Description

Moved contributor and license page to profile

---

## ✅ Related Issues

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Contributors page accessible from navigation, displaying project contributors with links to their GitHub profiles.

* **Refactor**
  * Reorganized the Profile page by separating the contributors section into a dedicated route.
  * Streamlined the Settings page interface by removing redundant navigation options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->