### PR TITLE
feat(ui): display station abbreviations on travel cards (#240)

### DIFF
--- a/lib/src/common/constants/station_code.dart
+++ b/lib/src/common/constants/station_code.dart
@@ -644,4 +644,31 @@ class StationRegistry {
     if (stationCode == null) return false;
     return _stations.containsKey(stationCode.toUpperCase().trim());
   }
+
+  /// If not found, returns the original input.
+  static String getCode(String? nameOrCode) {
+    if (nameOrCode == null || nameOrCode.trim().isEmpty) return '';
+    final clean = nameOrCode.trim().toUpperCase();
+
+    // 1. If it's already a valid code key
+    if (_stations.containsKey(clean)) {
+      return clean;
+    }
+
+    // 2. Exact match against station full names (values)
+    for (final entry in _stations.entries) {
+      if (entry.value.toUpperCase() == clean) {
+        return entry.key;
+      }
+    }
+
+    // 3. Partial match if input contains full station name
+    for (final entry in _stations.entries) {
+      if (clean.contains(entry.value.toUpperCase())) {
+        return entry.key;
+      }
+    }
+
+    return nameOrCode.trim();
+  }
 }

--- a/lib/src/common/constants/string_extension.dart
+++ b/lib/src/common/constants/string_extension.dart
@@ -1,11 +1,20 @@
+import 'package:namma_wallet/src/common/constants/station_code.dart';
+
 extension StringExtensions on String? {
   /// Returns true if the string is null, empty, or contains only whitespace
   bool get isNullOrEmpty {
-    return this == null || this!.trim().isEmpty;
+    final self = this;
+    return self == null || self.trim().isEmpty;
   }
 
   /// Returns true if the string is NOT null and contains actual text
   bool get isNotNullOrEmpty {
-    return this != null && this!.trim().isNotEmpty;
+    final self = this;
+    return self != null && self.trim().isNotEmpty;
+  }
+
+  /// Converts a station or city name to its short code abbreviation (e.g., "Chennai Central" -> "MAS").
+  String get toStationAbbreviation {
+    return StationRegistry.getCode(this);
   }
 }

--- a/lib/src/features/travel/presentation/widgets/travel_ticket_card_widget.dart
+++ b/lib/src/features/travel/presentation/widgets/travel_ticket_card_widget.dart
@@ -1,5 +1,6 @@
 // A dedicated, reusable widget for rendering the content of a wallet card.
 import 'package:flutter/material.dart';
+import 'package:namma_wallet/src/common/constants/string_extension.dart';
 import 'package:namma_wallet/src/common/domain/models/ticket.dart';
 import 'package:namma_wallet/src/common/enums/ticket_type.dart';
 import 'package:namma_wallet/src/common/helper/date_time_converter.dart';
@@ -146,12 +147,12 @@ class TravelTicketCardWidget extends StatelessWidget {
                           const SizedBox(width: 8),
                           Expanded(
                             child: Text(
-                              from,
+                              from.toStationAbbreviation,
                               style: Paragraph02(
                                 color: Theme.of(context).colorScheme.onSurface,
                               ).semiBold,
                               overflow: TextOverflow.ellipsis,
-                              maxLines: 2,
+                              maxLines: 1,
                             ),
                           ),
                         ],
@@ -207,12 +208,12 @@ class TravelTicketCardWidget extends StatelessWidget {
                           const SizedBox(width: 8),
                           Expanded(
                             child: Text(
-                              to,
+                              to.toStationAbbreviation,
                               style: Paragraph02(
                                 color: Theme.of(context).colorScheme.onSurface,
                               ).semiBold,
                               overflow: TextOverflow.ellipsis,
-                              maxLines: 2,
+                              maxLines: 1,
                             ),
                           ),
                         ],


### PR DESCRIPTION
# 📌 Description

Updated `TravelTicketCardWidget` to display standard station code abbreviations (e.g., `MAS`, `SBC`) for origin and destination locations instead of long full station names. This prevents text wrapping and overflow issues on compact card layouts while preserving a clean UI.

Key changes:
- Added static `getCode(String? nameOrCode)` lookup helper to `StationRegistry`.
- Added `toStationAbbreviation` getter to `StringExtensions`.
- Integrated `toStationAbbreviation` on origin and destination chips inside `TravelTicketCardWidget`.

---

## ✅ Related Issues

Closes #240

---

## 📝 Pull Request Checklist

- [x] **Base branch is `main`.**  
- [x] **Avoid returning `Widget` from functions or getters.**  
- [x] **Always use `StatelessWidget`** for static UI components.  
- [x] **Model classes must be generated using [`dart_mappable`](https://pub.dev/packages/dart_mappable)**.  
- [x] **Follow [Conventional Commits](https://www.conventionalcommits.org/) and branch naming conventions.**  
- [x] **Code is formatted** before committing. (`dart format .` / `fvm dart format .`)  
- [x] **Follow naming conventions for widgets and views.**  
- [x] **Static checks pass locally.** (`flutter analyze` / `fvm flutter analyze`)  
- [x] **Screenshots / recordings** added for UI changes.  
- [ ] **Breaking changes** are called out clearly and migration notes included.  
- [x] **No secrets or sensitive data** committed.  

---

## 🔍 Validation Notes (optional)

- **Manual Testing:** Tested locally on Android emulator/device by rendering tickets with long origin/destination strings (e.g., "MGR Chennai Central", "Bangalore City") and verifying that `MAS` and `SBC` display on a single line without text overflow.
- **Static Analysis:** Verified clean output with `dart format .` and `flutter analyze`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic conversion of station or city names to station-code abbreviations.
  * Supports matching valid codes, exact names, partial names, and safely preserves unmatched input.

* **Improvements**
  * Travel ticket cards now display concise origin and destination station codes.
  * Location labels are limited to a single line for a cleaner layout.
  * Improved null and empty-string handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->