### PR TITLE
fix(ci): use standard macos-latest runner for iOS pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,7 +243,7 @@ jobs:
 
   ios:
     name: Build & Ship iOS
-    runs-on: macos-latest-xlarge
+    runs-on: macos-latest
     timeout-minutes: 90
     needs: [changes, gate]
     if: needs.changes.outputs.code == 'true'


### PR DESCRIPTION
# 📌 Description

Replaces `macos-latest-xlarge` with the standard GitHub-hosted `macos-latest` runner in `.github/workflows/release.yml`.

### Root Cause
`macos-latest-xlarge` is a paid-only GitHub Actions larger runner tier that requires an active payment method and spending limit configured on the account. When triggered without paid billing set up, GitHub immediately halts the job with:
> *The job was not started because recent account payments have failed or your spending limit needs to be increased. Please check the 'Billing & plans' section in your settings*

### Solution
Switch back to standard `macos-latest`, which runs on GitHub-hosted Apple Silicon (M-series) macOS runners and operates within standard/free GitHub Actions allowances.

---

## 📝 Pull Request Checklist

- [x] **Base branch is `main`.**
- [x] **Follow [Conventional Commits](https://www.conventionalcommits.org/) and branch naming conventions.**
- [x] **No secrets or sensitive data** committed.