### PR TITLE
fix(android): disable Gradle configuration cache to fix assembleRelease failure

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryErro
 android.useAndroidX=true
 android.enableJetifier=true
 org.gradle.caching=true
-org.gradle.configuration-cache=true
+org.gradle.configuration-cache=false
 org.gradle.parallel=true
 org.gradle.configureondemand=true
 org.gradle.daemon=false


### PR DESCRIPTION
# 📌 Description

Disables Gradle Configuration Cache (`org.gradle.configuration-cache=false`) in `android/gradle.properties`.

### Root Cause Analysis
The build failure:
```text
Configuration cache state could not be cached: ... error writing value of type 'java.lang.ref.ReferenceQueue'
> Unable to make field private volatile java.lang.ref.Reference java.lang.ref.ReferenceQueue.head accessible
```
was caused by `org.gradle.configuration-cache=true`.

1. When `org.gradle.configuration-cache=true` is enabled, Gradle attempts to serialize the entire task graph and action closures into cache.
2. Flutter's Gradle plugin tasks (such as `:app:ReleaseMinSdkCheck`) hold references to AGP variant services and Kotlin stored property storage, which in turn contain `WeakHashMap` and `java.lang.ref.ReferenceQueue` objects.
3. Gradle's configuration cache serializer cannot serialize JVM dynamic reference queues, and Java reflection encapsulation blocks field-level serialization.
4. Flutter's Android Gradle plugin does not support Gradle Configuration Cache (documented Flutter limitation).

### Solution
Set `org.gradle.configuration-cache=false` in `android/gradle.properties`. Standard Gradle build caching (`org.gradle.caching=true`) and parallel execution (`org.gradle.parallel=true`) remain active for fast builds.

---

## 📝 Pull Request Checklist

- [x] **Base branch is `main`.**
- [x] **Follow [Conventional Commits](https://www.conventionalcommits.org/) and branch naming conventions.**
- [x] **Static checks pass locally.**
- [x] **No secrets or sensitive data** committed.