### PR TITLE
fix(ios): strip unused permissions (including location) via GCC_PREPROCESSOR_DEFINITIONS

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -65,6 +65,23 @@ post_install do |installer|
       if target.name.include?("Pods-Share Extension") || target.name.include?("share_handler_ios_models")
         config.build_settings['APPLICATION_EXTENSION_API_ONLY'] = 'YES'
       end
+
+      # Strip unused permissions from permission_handler to avoid App Store ITMS-90683 warnings
+      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
+        '$(inherited)',
+        'PERMISSION_CAMERA=1',
+        'PERMISSION_PHOTOS=1',
+        'PERMISSION_NOTIFICATIONS=1',
+        'PERMISSION_LOCATION=0',
+        'PERMISSION_EVENTS=0',
+        'PERMISSION_REMINDERS=0',
+        'PERMISSION_CONTACTS=0',
+        'PERMISSION_MICROPHONE=0',
+        'PERMISSION_SPEECH_RECOGNIZER=0',
+        'PERMISSION_BLUETOOTH=0',
+        'PERMISSION_APP_TRACKING_TRANSPARENCY=0',
+        'PERMISSION_CRITICAL_ALERTS=0',
+      ]
     end
   end
 

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -32,8 +32,6 @@
 	<string>Camera access is required to scan QR codes</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>This app needs photo library access to scan barcodes from images.</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Location access is used to provide relevant travel details, station directions, and ticket locations.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -32,6 +32,8 @@
 	<string>Camera access is required to scan QR codes</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>This app needs photo library access to scan barcodes from images.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Location access is used to provide relevant travel details, station directions, and ticket locations.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
### Description

Resolves App Store Connect validation warning **ITMS-90683: Missing purpose string in Info.plist** without adding unnecessary location permissions to `Info.plist`.

### Root Cause
The `permission_handler_apple` plugin compiles references to CoreLocation and other permission APIs by default unless excluded at compile time. Apple's binary scanner detects these symbols in the app bundle and demands `NSLocationWhenInUseUsageDescription`.

### Solution
Configured `GCC_PREPROCESSOR_DEFINITIONS` in [ios/Podfile](file:///home/harish/Developer/namma_wallet/ios/Podfile) to compile **only** the permissions the app actually needs:
- `PERMISSION_CAMERA=1`
- `PERMISSION_PHOTOS=1`
- `PERMISSION_NOTIFICATIONS=1`
- Explicitly disabled unused permissions: `PERMISSION_LOCATION=0`, `PERMISSION_MICROPHONE=0`, `PERMISSION_CONTACTS=0`, `PERMISSION_BLUETOOTH=0`, `PERMISSION_EVENTS=0`, `PERMISSION_REMINDERS=0`, `PERMISSION_SPEECH_RECOGNIZER=0`, `PERMISSION_APP_TRACKING_TRANSPARENCY=0`, `PERMISSION_CRITICAL_ALERTS=0`.

This removes all CoreLocation and unused permission symbols from the compiled binary, completely satisfying Apple's submission checks without requesting location access from users.

---

## 📝 Pull Request Checklist
- [x] Base branch is `main`.
- [x] Follow Conventional Commits and branch naming conventions.
- [x] Static checks pass locally (`fvm flutter analyze`).
- [x] No secrets or sensitive data committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS builds by limiting permission-related components to camera, photo library, and notification access.
  * Removed unused permission capabilities, reducing unnecessary app permissions and configuration overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->