### PR TITLE
ci(dependabot): skip CI workflows and configure auto-merge

### DIFF
--- a/.github/workflows/android-lint.yml
+++ b/.github/workflows/android-lint.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   android-lint:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   format-analyze:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -225,6 +226,7 @@ jobs:
           fi
 
   test-coverage:
+    if: github.actor != 'dependabot[bot]'
     needs: format-analyze
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/conventional_branch_commit_check.yml
+++ b/.github/workflows/conventional_branch_commit_check.yml
@@ -18,7 +18,7 @@ jobs:
     name: Validate Branch Name
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: github.actor != 'imgbot[bot]' && github.actor != 'ImgBotApp' && !startsWith(github.head_ref, 'imgbot')
+    if: github.actor != 'dependabot[bot]' && !startsWith(github.head_ref, 'dependabot') && github.actor != 'imgbot[bot]' && github.actor != 'ImgBotApp' && !startsWith(github.head_ref, 'imgbot')
     permissions:
       contents: read
       pull-requests: read
@@ -55,7 +55,7 @@ jobs:
     name: Conventional Commits
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: github.actor != 'imgbot[bot]' && github.actor != 'ImgBotApp' && !startsWith(github.head_ref, 'imgbot')
+    if: github.actor != 'dependabot[bot]' && !startsWith(github.head_ref, 'dependabot') && github.actor != 'imgbot[bot]' && github.actor != 'ImgBotApp' && !startsWith(github.head_ref, 'imgbot')
     needs: branch-name
     permissions:
       contents: read

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,38 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot-auto-merge:
+    name: Auto-merge Dependabot PR
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.AUTOMERGE_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Approve PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.AUTOMERGE_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Enable Auto-Merge
+        run: |
+          gh pr merge --auto --squash "$PR_URL" || gh pr merge --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.AUTOMERGE_PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/greenlight.yml
+++ b/.github/workflows/greenlight.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   greenlight:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   swiftlint:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
### Description
- Skips CI checks, AndroidLint, SwiftLint, Greenlight, and Conventional Commits workflows on Dependabot PRs.
- Adds auto-merge workflow for Dependabot PRs with fallback support for `AUTOMERGE_PAT` secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic approval and squash merging for eligible automated dependency updates.

* **Chores**
  * Updated continuous integration checks to skip selected validation jobs for automated dependency update pull requests.
  * Excluded these pull requests from branch, commit, and code-quality checks where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->